### PR TITLE
Accept custom env file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ function format (key, value) {
   return `${key}=${escapeNewlines(value)}`
 }
 
-module.exports = async function updateDotenv (env) {
-  const filename = path.join(process.cwd(), '.env')
+module.exports = async function updateDotenv (env, options = {}) {
+  const filename = options.path || path.join(process.cwd(), '.env')
 
   // Merge with existing values
   try {


### PR DESCRIPTION
Not always is the env file named .env or present at the root of the cwd. Accept the custom path argument will help solve such use cases.